### PR TITLE
docs: add contribution guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ This file applies to the entire monorepo:
 - Do not commit secrets or generated local env files (`.env`, `*.tfvars`, credentials).
 - Prefer updating existing files over introducing parallel patterns.
 - If you change behavior, update the nearest README/docs in the same area.
+- For branch, commit, and ticket conventions, follow `CONTRIBUTING.md` as the single source of truth.
 
 ## Formatting And Validation
 
@@ -124,4 +125,3 @@ Apply these when relevant:
 - Do not rotate or overwrite live cloud resources unless explicitly requested.
 - Do not destroy infrastructure as part of routine edits.
 - Do not change environment defaults (`dev`/`prod`, region, naming) without explicit request.
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing
+
+This repository follows a PR-to-`master` workflow.
+
+## Branching Workflow
+
+- Branch off `master`.
+- Keep branches short-lived and focused on a single change.
+- Open a pull request directly into `master`.
+- Merge via PR only (no direct pushes to `master`).
+- Delete branch after merge.
+
+## Branch Naming (Required)
+
+Branch format:
+
+- `<type>/<short-kebab-summary>`
+
+Allowed `<type>` values:
+
+- `feat`
+- `fix`
+- `chore`
+- `docs`
+- `refactor`
+- `test`
+- `hotfix`
+- `release`
+
+Rules:
+
+- Use lowercase only.
+- Use exactly one `/` between `type` and summary.
+- Summary must use letters, numbers, and `-` only.
+- Do not use `_` or spaces.
+
+Valid branch names:
+
+- `feat/monthly-availability-view`
+- `fix/login-callback-redirect`
+- `chore/update-dependencies`
+
+Invalid branch names:
+
+- `feature/monthly-availability-view` (invalid type)
+- `feat_monthly-availability-view` (missing `/`)
+- `feat/monthly_availability_view` (uses `_`)
+- `feat/Monthly-Availability-View` (contains uppercase)
+
+## Commit Messages (Required)
+
+Commit format:
+
+- Without ticket: `<type>: <short imperative summary>`
+- With ticket (optional): `<type>: <short imperative summary> (<ticket-id>)`
+
+Allowed `<type>` values:
+
+- `feat`
+- `fix`
+- `chore`
+- `docs`
+- `refactor`
+- `test`
+- `hotfix`
+- `release`
+
+Rules:
+
+- Use lowercase `type`.
+- Use one-line summary in imperative form (for example: `add`, `fix`, `update`).
+- Keep summary concise (target up to 72 characters).
+- Ticket ID is optional and should be added at the end in parentheses.
+
+Valid commit messages:
+
+- `feat: add monthly availability view`
+- `fix: handle missing access token`
+- `docs: update local setup steps`
+- `feat: add monthly availability view (PROJ-142)`
+- `fix: handle missing access token (JIRA-77)`
+
+Invalid commit messages:
+
+- `Feature: Add monthly availability view` (invalid type case)
+- `fix add monthly availability view` (missing `:`)
+- `feat(PROJ-142): add monthly availability view` (ticket must be suffix)
+
+## Tickets
+
+Tickets are optional and are not required in branch names. For commits, include ticket IDs only as an optional suffix: `(<ticket-id>)`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Modern, cloud-ready shift scheduling application.
 - Frontend docs: [frontend/README.md](frontend/README.md)
 - Backend docs: [backend/README.md](backend/README.md)
 - Infrastructure docs: [infrastructure/README.md](infrastructure/README.md)
+- Contribution guide: [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Monorepo Layout
 


### PR DESCRIPTION
## Summary
- add `CONTRIBUTING.md` as the central contribution policy document
- add contribution guide link in `README.md`
- update `AGENTS.md` to reference `CONTRIBUTING.md` as single source of truth

Closes #1
